### PR TITLE
feat(auth): agregar ruta POST /login con JWT y cookie httpOnly

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import morgan from 'morgan';
 import usuariosRouter from './routes/usuarios.routes.js';
 import analiticosRouter from './routes/analiticos.routes.js';
 import alumnoRoutes from './routes/alumnos.routes.js';
+import authRoutes from './routes/auth.routes.js';
 
 
 
@@ -11,6 +12,7 @@ const app = express();
 app.use(express.json());
 app.use(morgan('dev'));
 
+app.use('/api/auth', authRoutes)
 app.use('/api/usuarios', usuariosRouter);
 app.use('/api/analiticos', analiticosRouter);
 app.use('/api', alumnoRoutes);

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -1,0 +1,59 @@
+// src/routes/auth.routes.js
+import { Router } from 'express';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+import Usuario from '../models/Usuario.js';
+import { env } from '../config/env.js';
+
+
+
+const router = Router();
+
+router.post('/login', async (req, res) => {
+  let { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email y contraseña son obligatorios' });
+  }
+
+  // Normalizar email
+  email = String(email).trim().toLowerCase();
+
+  try {
+    // Buscar usuario por email
+    const usuario = await Usuario.findOne({
+      where: { email },
+      attributes: ['id', 'nombre', 'email', 'password', 'rol'],
+    });
+
+    // No revelar si falló email o password
+    if (!usuario) return res.status(401).json({ error: 'Credenciales inválidas' });
+
+    // Verificar contraseña hasheada
+    const ok = await bcrypt.compare(password, usuario.password);
+    if (!ok) return res.status(401).json({ error: 'Credenciales inválidas' });
+    console.log(`Usuario ${usuario.email} autenticado correctamente`);
+    // Generar JWT
+    const token = jwt.sign(
+      { id: usuario.id, nombre: usuario.nombre, email: usuario.email, rol: usuario.rol },
+      env.jwt.secret,
+      { expiresIn: '1h', issuer: 'sysacad' }
+    );
+
+    // Enviar token en cookie httpOnly
+    res.cookie('jwtSysacad', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production', // true si servís por HTTPS en prod
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 1000, // 1 hora
+    });
+
+    return res.status(200).json({ mensaje: 'Login exitoso' });
+  } catch (error) {
+    console.error('Error en login:', error);
+    return res.status(500).json({ error: 'Error interno del servidor' });
+  }
+});
+
+export default router;

--- a/src/tests/routes/auth.routes.test.js
+++ b/src/tests/routes/auth.routes.test.js
@@ -1,0 +1,90 @@
+// src/tests/routes/auth.routes.test.js
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+// ⚠️ Mockear el modelo y bcrypt ANTES de importarlos en la ruta
+jest.unstable_mockModule('../../models/Usuario.js', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn() },
+}));
+
+jest.unstable_mockModule('bcrypt', () => ({
+  __esModule: true,
+  default: { compare: jest.fn() },
+}));
+
+// Importar los módulos mockeados y la ruta (con top-level await en ESM)
+const { default: Usuario } = await import('../../models/Usuario.js');
+const { default: bcrypt } = await import('bcrypt');
+const { default: authRouter } = await import('../../routes/auth.routes.js');
+
+describe('POST /auth/login', () => {
+  let app;
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'test-secret';
+    app = express();
+    app.use(express.json());
+    app.use('/auth', authRouter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('400 si faltan email o password', async () => {
+    const res = await request(app).post('/auth/login').send({ email: 'test@example.com' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/obligatorios/i);
+  });
+
+  test('401 si el usuario no existe', async () => {
+    Usuario.findOne.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'noexiste@example.com', password: 'x' });
+
+    expect(Usuario.findOne).toHaveBeenCalledWith({
+      where: { email: 'noexiste@example.com' },
+      attributes: ['id', 'nombre', 'email', 'password', 'rol'],
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Credenciales inválidas/i);
+  });
+
+  test('401 si la contraseña es inválida', async () => {
+    Usuario.findOne.mockResolvedValue({
+      id: 1, nombre: 'Branko', email: 'branko@example.com', password: 'hash', rol: 'admin',
+    });
+    bcrypt.compare.mockResolvedValue(false);
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'branko@example.com', password: 'malapass' });
+
+    expect(bcrypt.compare).toHaveBeenCalledWith('malapass', 'hash');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/Credenciales inválidas/i);
+  });
+
+  test('200 y setea cookie cuando el login es exitoso', async () => {
+    Usuario.findOne.mockResolvedValue({
+      id: 1, nombre: 'Branko', email: 'branko@example.com', password: 'hash', rol: 'admin',
+    });
+    bcrypt.compare.mockResolvedValue(true);
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'branko@example.com', password: 'correcta' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.mensaje).toMatch(/Login exitoso/i);
+
+    const cookies = res.headers['set-cookie'] || [];
+    expect(cookies.length).toBeGreaterThan(0);
+    expect(cookies[0]).toMatch(/jwtSysacad=/);
+    expect(cookies[0]).toMatch(/HttpOnly/);
+  });
+});


### PR DESCRIPTION
Resumen: Se incorpora endpoint de login que valida credenciales, firma JWT (1h) y lo envía en cookie httpOnly jwtSysacad.

Cómo probar:

POST /api/login body: { "email": "x@y.com", "password": "..." }

Esperado: 200 + cookie jwtSysacad.

Credenciales inválidas → 401.

Checklist:

 El endpoint responde 200/401 correctamente

 Cookie httpOnly seteada

 JWT_SECRET documentado en README / .env.example